### PR TITLE
PR5: add query, validation, and stats APIs

### DIFF
--- a/shelff/query.go
+++ b/shelff/query.go
@@ -1,0 +1,256 @@
+package shelff
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// ScanBooks scans the library for PDF files and their sidecar status.
+// If recursive is true, scans subdirectories.
+// Excludes the .shelff/ config directory from results.
+func (l *Library) ScanBooks(recursive bool) ([]BookEntry, error) {
+	entries := make([]BookEntry, 0)
+	err := l.walkLibraryFiles(recursive, func(path string, d fs.DirEntry) error {
+		if !isPDFPath(path) {
+			return nil
+		}
+
+		hasSidecar, err := isRegularFile(SidecarPath(path))
+		if err != nil {
+			return err
+		}
+
+		var sidecarPath *string
+		if hasSidecar {
+			value := SidecarPath(path)
+			sidecarPath = &value
+		}
+
+		entries = append(entries, BookEntry{
+			PDFPath:     path,
+			SidecarPath: sidecarPath,
+			HasSidecar:  hasSidecar,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(entries, func(a BookEntry, b BookEntry) int {
+		return strings.Compare(a.PDFPath, b.PDFPath)
+	})
+	return entries, nil
+}
+
+// FindOrphanedSidecars finds sidecar JSON files that have no corresponding PDF.
+// Scans recursively.
+func (l *Library) FindOrphanedSidecars() ([]OrphanedSidecar, error) {
+	orphaned := make([]OrphanedSidecar, 0)
+	err := l.walkLibraryFiles(true, func(path string, d fs.DirEntry) error {
+		if !IsSidecarPath(path) {
+			return nil
+		}
+
+		expectedPDF, ok := PDFPathFromSidecar(path)
+		if !ok {
+			return nil
+		}
+
+		hasPDF, err := isRegularFile(expectedPDF)
+		if err != nil {
+			return err
+		}
+		if hasPDF {
+			return nil
+		}
+
+		orphaned = append(orphaned, OrphanedSidecar{
+			SidecarPath: path,
+			ExpectedPDF: expectedPDF,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(orphaned, func(a OrphanedSidecar, b OrphanedSidecar) int {
+		return strings.Compare(a.SidecarPath, b.SidecarPath)
+	})
+	return orphaned, nil
+}
+
+// Stats computes aggregate statistics about the library.
+// Scans all PDFs and sidecars recursively.
+func (l *Library) Stats() (*LibraryStats, error) {
+	books, err := l.ScanBooks(true)
+	if err != nil {
+		return nil, err
+	}
+	orphaned, err := l.FindOrphanedSidecars()
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &LibraryStats{
+		CategoryCounts:   make(map[string]int),
+		TagCounts:        make(map[string]int),
+		StatusCounts:     make(map[string]int),
+		OrphanedSidecars: len(orphaned),
+		TotalPDFs:        len(books),
+	}
+
+	for _, book := range books {
+		if !book.HasSidecar {
+			stats.WithoutSidecar++
+			stats.StatusCounts[""]++
+			continue
+		}
+
+		stats.WithSidecar++
+
+		meta, err := ReadSidecar(book.PDFPath)
+		if err != nil {
+			return nil, err
+		}
+		if meta == nil {
+			stats.WithoutSidecar++
+			stats.WithSidecar--
+			stats.StatusCounts[""]++
+			continue
+		}
+
+		if meta.Category != nil {
+			stats.CategoryCounts[*meta.Category]++
+		}
+
+		perBookTags := make(map[string]struct{}, len(meta.Tags))
+		for _, tag := range meta.Tags {
+			if _, exists := perBookTags[tag]; exists {
+				continue
+			}
+			perBookTags[tag] = struct{}{}
+			stats.TagCounts[tag]++
+		}
+
+		status := ""
+		if meta.Reading != nil && meta.Reading.Status != nil {
+			status = *meta.Reading.Status
+		}
+		stats.StatusCounts[status]++
+	}
+
+	return stats, nil
+}
+
+// CollectAllTags scans all sidecar files and returns the union of all tags.
+// This is the canonical tag set — tags.json only defines display order.
+func (l *Library) CollectAllTags() ([]string, error) {
+	books, err := l.ScanBooks(true)
+	if err != nil {
+		return nil, err
+	}
+
+	tagSet := make(map[string]struct{})
+	for _, book := range books {
+		if !book.HasSidecar {
+			continue
+		}
+
+		meta, err := ReadSidecar(book.PDFPath)
+		if err != nil {
+			return nil, err
+		}
+		if meta == nil {
+			continue
+		}
+
+		for _, tag := range meta.Tags {
+			tagSet[tag] = struct{}{}
+		}
+	}
+
+	tagsConfig, err := l.ReadTagOrder()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, 0, len(tagSet))
+	seen := make(map[string]struct{}, len(tagSet))
+	for _, tag := range tagsConfig.TagOrder {
+		if _, ok := tagSet[tag]; !ok {
+			continue
+		}
+		if _, ok := seen[tag]; ok {
+			continue
+		}
+		seen[tag] = struct{}{}
+		result = append(result, tag)
+	}
+
+	extras := make([]string, 0, len(tagSet)-len(result))
+	for tag := range tagSet {
+		if _, ok := seen[tag]; ok {
+			continue
+		}
+		extras = append(extras, tag)
+	}
+	sort.Strings(extras)
+	result = append(result, extras...)
+
+	return result, nil
+}
+
+func (l *Library) walkLibraryFiles(recursive bool, visit func(path string, d fs.DirEntry) error) error {
+	return filepath.WalkDir(l.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == l.root {
+			return nil
+		}
+
+		if d.Type()&os.ModeSymlink != 0 {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			if d.Name() == ConfigDir {
+				return filepath.SkipDir
+			}
+			if !recursive {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		return visit(path, d)
+	})
+}
+
+func isPDFPath(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".pdf")
+}
+
+func isRegularFile(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.Mode().IsRegular(), nil
+}

--- a/shelff/query_test.go
+++ b/shelff/query_test.go
@@ -1,0 +1,239 @@
+package shelff_test
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skoji/shelff-go/shelff"
+)
+
+func TestScanBooksRecursiveSkipsConfigDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	library := openTestLibrary(t, root)
+	topPDF := writeTestPDF(t, root, "top.pdf")
+	nestedDir := filepath.Join(root, "nested")
+	configDir := filepath.Join(root, shelff.ConfigDir)
+	mkdirAll(t, nestedDir, configDir)
+	nestedPDF := writeTestPDF(t, nestedDir, "nested.PDF")
+	writeTestPDF(t, configDir, "ignored.pdf")
+	if _, err := shelff.CreateSidecar(nestedPDF); err != nil {
+		t.Fatalf("CreateSidecar returned error: %v", err)
+	}
+
+	books, err := library.ScanBooks(true)
+	if err != nil {
+		t.Fatalf("ScanBooks returned error: %v", err)
+	}
+
+	if len(books) != 2 {
+		t.Fatalf("len(books) = %d, want 2", len(books))
+	}
+	if books[0].PDFPath != nestedPDF && books[0].PDFPath != topPDF {
+		t.Fatalf("unexpected PDFPath %q", books[0].PDFPath)
+	}
+	if got := findBook(t, books, nestedPDF); !got.HasSidecar || got.SidecarPath == nil || *got.SidecarPath != shelff.SidecarPath(nestedPDF) {
+		t.Fatalf("nested book = %#v, want sidecar present", got)
+	}
+	if got := findBook(t, books, topPDF); got.HasSidecar || got.SidecarPath != nil {
+		t.Fatalf("top book = %#v, want no sidecar", got)
+	}
+}
+
+func TestScanBooksNonRecursiveOnlyReturnsTopLevelPDFs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	library := openTestLibrary(t, root)
+	topPDF := writeTestPDF(t, root, "top.pdf")
+	mkdirAll(t, filepath.Join(root, "nested"))
+	writeTestPDF(t, filepath.Join(root, "nested"), "nested.pdf")
+
+	books, err := library.ScanBooks(false)
+	if err != nil {
+		t.Fatalf("ScanBooks returned error: %v", err)
+	}
+	if len(books) != 1 || books[0].PDFPath != topPDF {
+		t.Fatalf("books = %#v, want only top-level PDF", books)
+	}
+}
+
+func TestFindOrphanedSidecarsFindsMissingPDFs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	library := openTestLibrary(t, root)
+	validPDF := writeTestPDF(t, root, "valid.pdf")
+	if _, err := shelff.CreateSidecar(validPDF); err != nil {
+		t.Fatalf("CreateSidecar returned error: %v", err)
+	}
+	orphanPath := shelff.SidecarPath(filepath.Join(root, "orphan.pdf"))
+	writeRawJSONFile(t, orphanPath, `{"schemaVersion":1,"metadata":{"dc:title":"orphan"}}`)
+
+	orphaned, err := library.FindOrphanedSidecars()
+	if err != nil {
+		t.Fatalf("FindOrphanedSidecars returned error: %v", err)
+	}
+	if len(orphaned) != 1 {
+		t.Fatalf("len(orphaned) = %d, want 1", len(orphaned))
+	}
+	if orphaned[0].SidecarPath != orphanPath {
+		t.Fatalf("SidecarPath = %q, want %q", orphaned[0].SidecarPath, orphanPath)
+	}
+}
+
+func TestCollectAllTagsUsesConfiguredOrderThenAlphabeticalRemainder(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	library := openTestLibrary(t, root)
+	writeTagsSidecar(t, root, "one.pdf", []string{"mystery", "history"})
+	writeTagsSidecar(t, root, "two.pdf", []string{"sci-fi"})
+	if err := library.WriteTagOrder(&shelff.TagOrder{
+		Version:  shelff.SchemaVersion,
+		TagOrder: []string{"history", "unused"},
+	}); err != nil {
+		t.Fatalf("WriteTagOrder returned error: %v", err)
+	}
+
+	tags, err := library.CollectAllTags()
+	if err != nil {
+		t.Fatalf("CollectAllTags returned error: %v", err)
+	}
+	want := []string{"history", "mystery", "sci-fi"}
+	if !slices.Equal(tags, want) {
+		t.Fatalf("CollectAllTags = %#v, want %#v", tags, want)
+	}
+}
+
+func TestStatsCountsBooksTagsCategoriesStatusesAndOrphans(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	library := openTestLibrary(t, root)
+
+	readingPDF := writeCategorySidecar(t, root, "reading.pdf", "Fiction")
+	readingMeta := mustReadSidecar(t, readingPDF)
+	readingMeta.Tags = []string{"fantasy", "fantasy", "history"}
+	readingStatus := shelff.StatusReading
+	readingMeta.Reading = &shelff.ReadingProgress{
+		LastReadPage: 10,
+		LastReadAt:   mustParseTime(t, "2026-03-26T09:00:00Z"),
+		TotalPages:   100,
+		Status:       &readingStatus,
+	}
+	if err := shelff.WriteSidecar(readingPDF, readingMeta); err != nil {
+		t.Fatalf("WriteSidecar returned error: %v", err)
+	}
+
+	noReadingPDF := writeTagsSidecar(t, root, "noreading.pdf", []string{"history"})
+	writeTestPDF(t, root, "plain.pdf")
+	writeRawJSONFile(t, shelff.SidecarPath(filepath.Join(root, "orphan.pdf")), `{"schemaVersion":1,"metadata":{"dc:title":"orphan"}}`)
+
+	stats, err := library.Stats()
+	if err != nil {
+		t.Fatalf("Stats returned error: %v", err)
+	}
+	if stats.TotalPDFs != 3 || stats.WithSidecar != 2 || stats.WithoutSidecar != 1 || stats.OrphanedSidecars != 1 {
+		t.Fatalf("stats counts = %#v, want totals 3/2/1/1", stats)
+	}
+	if stats.CategoryCounts["Fiction"] != 1 {
+		t.Fatalf("CategoryCounts = %#v, want Fiction=1", stats.CategoryCounts)
+	}
+	if stats.TagCounts["fantasy"] != 1 || stats.TagCounts["history"] != 2 {
+		t.Fatalf("TagCounts = %#v, want fantasy=1 history=2", stats.TagCounts)
+	}
+	if stats.StatusCounts[shelff.StatusReading] != 1 || stats.StatusCounts[""] != 2 {
+		t.Fatalf("StatusCounts = %#v, want reading=1 empty=2", stats.StatusCounts)
+	}
+	if _, err := library.Validate(noReadingPDF); err != nil && !errors.Is(err, shelff.ErrSidecarNotFound) {
+		t.Fatalf("Validate on valid sidecar err = %v", err)
+	}
+}
+
+func TestValidateReturnsErrorsForInvalidSidecar(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	library := openTestLibrary(t, root)
+	pdfPath := writeTestPDF(t, root, "book.pdf")
+	writeRawJSONFile(t, shelff.SidecarPath(pdfPath), `{
+  "schemaVersion": 2,
+  "metadata": {},
+  "reading": {
+    "lastReadPage": 0,
+    "lastReadAt": "not-a-time",
+    "totalPages": 0,
+    "status": "bogus"
+  }
+}`)
+
+	errs, err := library.Validate(pdfPath)
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Fatal("Validate errors = nil, want validation errors")
+	}
+
+	joined := strings.Join(errs, "\n")
+	for _, needle := range []string{"const 1", "missing required property \"dc:title\"", "invalid date-time", "expected one of", ">= 1"} {
+		if !strings.Contains(joined, needle) {
+			t.Fatalf("validation errors %q do not contain %q", joined, needle)
+		}
+	}
+}
+
+func TestValidateReturnsErrSidecarNotFoundWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	library := openTestLibrary(t, t.TempDir())
+	_, err := library.Validate(filepath.Join(t.TempDir(), "missing.pdf"))
+	if !errors.Is(err, shelff.ErrSidecarNotFound) {
+		t.Fatalf("Validate error = %v, want ErrSidecarNotFound", err)
+	}
+}
+
+func TestValidateRejectsTrailingJSONContent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	library := openTestLibrary(t, root)
+	pdfPath := writeTestPDF(t, root, "book.pdf")
+	writeRawJSONFile(t, shelff.SidecarPath(pdfPath), `{"schemaVersion":1,"metadata":{"dc:title":"ok"}}{"extra":true}`)
+
+	errs, err := library.Validate(pdfPath)
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0], "invalid JSON") {
+		t.Fatalf("Validate errors = %#v, want invalid JSON error", errs)
+	}
+}
+
+func findBook(t *testing.T, books []shelff.BookEntry, pdfPath string) shelff.BookEntry {
+	t.Helper()
+
+	for _, book := range books {
+		if book.PDFPath == pdfPath {
+			return book
+		}
+	}
+	t.Fatalf("book with PDFPath %q not found", pdfPath)
+	return shelff.BookEntry{}
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("time.Parse(%q): %v", value, err)
+	}
+	return parsed
+}

--- a/shelff/schema/sidecar.schema.json
+++ b/shelff/schema/sidecar.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skoji.dev/shelff/schemas/sidecar/v1",
+  "title": "shelff Sidecar Metadata",
+  "description": "Metadata for a single PDF file managed by shelff. Stored as a sidecar file named {filename}.pdf.meta.json alongside the PDF.",
+  "type": "object",
+  "required": ["schemaVersion", "metadata"],
+  "additionalProperties": true,
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Must be 1 for this version of the specification."
+    },
+    "metadata": {
+      "$ref": "#/$defs/DublinCoreMetadata"
+    },
+    "reading": {
+      "$ref": "#/$defs/ReadingProgress"
+    },
+    "display": {
+      "$ref": "#/$defs/DisplaySettings"
+    },
+    "category": {
+      "type": "string",
+      "description": "Category name assigned to this book. A book belongs to at most one category."
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Tags assigned to this book. A book can have zero or more tags."
+    }
+  },
+  "$defs": {
+    "DublinCoreMetadata": {
+      "type": "object",
+      "description": "Metadata based on the Dublin Core Metadata Element Set. Field names use the 'dc:' prefix following Dublin Core convention.",
+      "required": ["dc:title"],
+      "additionalProperties": true,
+      "properties": {
+        "dc:title": {
+          "type": "string",
+          "description": "The title of the book."
+        },
+        "dc:creator": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Authors or creators of the book."
+        },
+        "dc:date": {
+          "type": "string",
+          "description": "Publication date. Typically in ISO 8601 date format (e.g. \"2024-01-15\"), but not strictly enforced."
+        },
+        "dc:publisher": {
+          "type": "string",
+          "description": "Publisher of the book."
+        },
+        "dc:language": {
+          "type": "string",
+          "description": "Language of the book (e.g. \"ja\", \"en\")."
+        },
+        "dc:subject": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Subject or topic keywords."
+        },
+        "dc:identifier": {
+          "type": "string",
+          "description": "An identifier for the book (e.g. ISBN, DOI)."
+        }
+      }
+    },
+    "ReadingProgress": {
+      "type": "object",
+      "description": "Reading progress and status for this book.",
+      "required": ["lastReadPage", "lastReadAt", "totalPages"],
+      "additionalProperties": false,
+      "properties": {
+        "lastReadPage": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The last page the reader was on (1-indexed)."
+        },
+        "lastReadAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the book was last read. ISO 8601 date-time in UTC."
+        },
+        "totalPages": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Total number of pages in the PDF."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["unread", "reading", "finished"],
+          "description": "Reading status. 'unread' = not yet started, 'reading' = in progress, 'finished' = completed."
+        },
+        "finishedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the book was marked as finished. ISO 8601 date-time in UTC."
+        }
+      }
+    },
+    "DisplaySettings": {
+      "type": "object",
+      "description": "Display preferences for rendering this PDF.",
+      "required": ["direction"],
+      "additionalProperties": false,
+      "properties": {
+        "direction": {
+          "type": "string",
+          "enum": ["LTR", "RTL"],
+          "description": "Reading direction. 'LTR' = left-to-right, 'RTL' = right-to-left."
+        },
+        "pageLayout": {
+          "type": "string",
+          "enum": ["single", "spread", "spread-with-cover"],
+          "description": "Page layout mode. 'single' = one page at a time, 'spread' = two pages side by side, 'spread-with-cover' = spread with first page displayed alone."
+        }
+      }
+    }
+  }
+}

--- a/shelff/validate.go
+++ b/shelff/validate.go
@@ -1,0 +1,211 @@
+package shelff
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
+)
+
+//go:embed schema/sidecar.schema.json
+var embeddedSidecarSchema []byte
+
+type jsonSchema struct {
+	Type                 string                 `json:"type"`
+	Required             []string               `json:"required"`
+	AdditionalProperties *bool                  `json:"additionalProperties,omitempty"`
+	Properties           map[string]*jsonSchema `json:"properties,omitempty"`
+	Items                *jsonSchema            `json:"items,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty"`
+	Const                any                    `json:"const,omitempty"`
+	Enum                 []string               `json:"enum,omitempty"`
+	Minimum              *int64                 `json:"minimum,omitempty"`
+	Format               string                 `json:"format,omitempty"`
+	Defs                 map[string]*jsonSchema `json:"$defs,omitempty"`
+}
+
+// Validate validates a sidecar JSON file against the schema.
+// Returns a list of validation errors (empty if valid).
+func (l *Library) Validate(pdfPath string) ([]string, error) {
+	data, err := os.ReadFile(SidecarPath(pdfPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrSidecarNotFound
+		}
+		return nil, err
+	}
+
+	value, err := jsonBytesToMap(data)
+	if err != nil {
+		return []string{fmt.Sprintf("invalid JSON: %v", err)}, nil
+	}
+
+	schema, err := loadSidecarSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	var validationErrors []string
+	validateJSONValue("$", value, schema, schema, &validationErrors)
+	return validationErrors, nil
+}
+
+func loadSidecarSchema() (*jsonSchema, error) {
+	var schema jsonSchema
+	if err := json.Unmarshal(embeddedSidecarSchema, &schema); err != nil {
+		return nil, err
+	}
+	return &schema, nil
+}
+
+func validateJSONValue(path string, value any, schema *jsonSchema, root *jsonSchema, errs *[]string) {
+	schema = resolveSchema(schema, root)
+	if schema == nil {
+		return
+	}
+
+	if schema.Const != nil && !matchesConst(value, schema.Const) {
+		*errs = append(*errs, fmt.Sprintf("%s: expected const %v, got %v", path, schema.Const, value))
+	}
+
+	switch schema.Type {
+	case "object":
+		validateJSONObject(path, value, schema, root, errs)
+	case "array":
+		validateJSONArray(path, value, schema, root, errs)
+	case "string":
+		validateJSONString(path, value, schema, errs)
+	case "integer":
+		validateJSONInteger(path, value, schema, errs)
+	}
+}
+
+func validateJSONObject(path string, value any, schema *jsonSchema, root *jsonSchema, errs *[]string) {
+	object, ok := value.(map[string]any)
+	if !ok {
+		*errs = append(*errs, fmt.Sprintf("%s: expected object", path))
+		return
+	}
+
+	for _, required := range schema.Required {
+		if _, ok := object[required]; !ok {
+			*errs = append(*errs, fmt.Sprintf("%s: missing required property %q", path, required))
+		}
+	}
+
+	for key, child := range schema.Properties {
+		if childValue, ok := object[key]; ok {
+			validateJSONValue(joinJSONPath(path, key), childValue, child, root, errs)
+		}
+	}
+
+	if schema.AdditionalProperties != nil && !*schema.AdditionalProperties {
+		for key := range object {
+			if _, ok := schema.Properties[key]; !ok {
+				*errs = append(*errs, fmt.Sprintf("%s: unexpected property %q", path, key))
+			}
+		}
+	}
+}
+
+func validateJSONArray(path string, value any, schema *jsonSchema, root *jsonSchema, errs *[]string) {
+	array, ok := value.([]any)
+	if !ok {
+		*errs = append(*errs, fmt.Sprintf("%s: expected array", path))
+		return
+	}
+	if schema.Items == nil {
+		return
+	}
+	for i, item := range array {
+		validateJSONValue(fmt.Sprintf("%s[%d]", path, i), item, schema.Items, root, errs)
+	}
+}
+
+func validateJSONString(path string, value any, schema *jsonSchema, errs *[]string) {
+	stringValue, ok := value.(string)
+	if !ok {
+		*errs = append(*errs, fmt.Sprintf("%s: expected string", path))
+		return
+	}
+
+	if len(schema.Enum) > 0 && !slices.Contains(schema.Enum, stringValue) {
+		*errs = append(*errs, fmt.Sprintf("%s: expected one of %v, got %q", path, schema.Enum, stringValue))
+	}
+	if schema.Format == "date-time" {
+		if _, err := time.Parse(time.RFC3339, stringValue); err != nil {
+			*errs = append(*errs, fmt.Sprintf("%s: invalid date-time %q", path, stringValue))
+		}
+	}
+}
+
+func validateJSONInteger(path string, value any, schema *jsonSchema, errs *[]string) {
+	integerValue, ok := asInt64(value)
+	if !ok {
+		*errs = append(*errs, fmt.Sprintf("%s: expected integer", path))
+		return
+	}
+
+	if schema.Minimum != nil && integerValue < *schema.Minimum {
+		*errs = append(*errs, fmt.Sprintf("%s: expected integer >= %d, got %d", path, *schema.Minimum, integerValue))
+	}
+}
+
+func resolveSchema(schema *jsonSchema, root *jsonSchema) *jsonSchema {
+	if schema == nil {
+		return nil
+	}
+	if schema.Ref == "" {
+		return schema
+	}
+	const prefix = "#/$defs/"
+	if !strings.HasPrefix(schema.Ref, prefix) {
+		return schema
+	}
+	name := strings.TrimPrefix(schema.Ref, prefix)
+	if root == nil || root.Defs == nil {
+		return schema
+	}
+	if resolved, ok := root.Defs[name]; ok {
+		return resolved
+	}
+	return schema
+}
+
+func matchesConst(value any, want any) bool {
+	gotInt, gotIsInt := asInt64(value)
+	wantInt, wantIsInt := asInt64(want)
+	if gotIsInt && wantIsInt {
+		return gotInt == wantInt
+	}
+	return value == want
+}
+
+func asInt64(value any) (int64, bool) {
+	switch v := value.(type) {
+	case json.Number:
+		i, err := v.Int64()
+		return i, err == nil
+	case float64:
+		i := int64(v)
+		if float64(i) != v {
+			return 0, false
+		}
+		return i, true
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	}
+	return 0, false
+}
+
+func joinJSONPath(base string, key string) string {
+	if base == "" {
+		return key
+	}
+	return base + "." + key
+}


### PR DESCRIPTION
## Summary
- add library query APIs for scanning books, finding orphaned sidecars, collecting tags, and computing library stats
- add sidecar schema validation backed by an embedded schema copy
- add tests covering recursive scanning, orphan detection, stats, tag ordering, and validation errors

## Testing
- go test ./...