### PR TITLE
PR4: add MCP book and config mutation tools

### DIFF
--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -327,7 +327,7 @@ func (s *Server) moveBook(_ context.Context, _ *mcp.CallToolRequest, in moveBook
 	if err != nil {
 		return nil, bookPathOutput{}, err
 	}
-	destDir, err := s.resolvePath(in.DestDir)
+	destDir, err := s.resolveDirectoryPath(in.DestDir)
 	if err != nil {
 		return nil, bookPathOutput{}, err
 	}
@@ -449,32 +449,32 @@ func (s *Server) readCategories(_ context.Context, _ *mcp.CallToolRequest, _ str
 	return nil, *categories, nil
 }
 
-func (s *Server) addCategory(_ context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, shelff.CategoryList, error) {
+func (s *Server) addCategory(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, shelff.CategoryList, error) {
 	if err := s.library.AddCategory(in.Name); err != nil {
 		return nil, shelff.CategoryList{}, err
 	}
-	return s.readCategories(context.Background(), nil, struct{}{})
+	return s.readCategories(ctx, nil, struct{}{})
 }
 
-func (s *Server) removeCategory(_ context.Context, _ *mcp.CallToolRequest, in cascadeNameInput) (*mcp.CallToolResult, shelff.CategoryList, error) {
+func (s *Server) removeCategory(ctx context.Context, _ *mcp.CallToolRequest, in cascadeNameInput) (*mcp.CallToolResult, shelff.CategoryList, error) {
 	if err := s.library.RemoveCategory(in.Name, in.Cascade); err != nil {
 		return nil, shelff.CategoryList{}, err
 	}
-	return s.readCategories(context.Background(), nil, struct{}{})
+	return s.readCategories(ctx, nil, struct{}{})
 }
 
-func (s *Server) renameCategory(_ context.Context, _ *mcp.CallToolRequest, in renameConfigInput) (*mcp.CallToolResult, shelff.CategoryList, error) {
+func (s *Server) renameCategory(ctx context.Context, _ *mcp.CallToolRequest, in renameConfigInput) (*mcp.CallToolResult, shelff.CategoryList, error) {
 	if err := s.library.RenameCategory(in.OldName, in.NewName, in.Cascade); err != nil {
 		return nil, shelff.CategoryList{}, err
 	}
-	return s.readCategories(context.Background(), nil, struct{}{})
+	return s.readCategories(ctx, nil, struct{}{})
 }
 
-func (s *Server) reorderCategories(_ context.Context, _ *mcp.CallToolRequest, in reorderNamesInput) (*mcp.CallToolResult, shelff.CategoryList, error) {
+func (s *Server) reorderCategories(ctx context.Context, _ *mcp.CallToolRequest, in reorderNamesInput) (*mcp.CallToolResult, shelff.CategoryList, error) {
 	if err := s.library.ReorderCategories(in.Names); err != nil {
 		return nil, shelff.CategoryList{}, err
 	}
-	return s.readCategories(context.Background(), nil, struct{}{})
+	return s.readCategories(ctx, nil, struct{}{})
 }
 
 func (s *Server) readTagOrder(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, shelff.TagOrder, error) {
@@ -485,32 +485,32 @@ func (s *Server) readTagOrder(_ context.Context, _ *mcp.CallToolRequest, _ struc
 	return nil, *tagOrder, nil
 }
 
-func (s *Server) addTagToOrder(_ context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, shelff.TagOrder, error) {
+func (s *Server) addTagToOrder(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, shelff.TagOrder, error) {
 	if err := s.library.AddTagToOrder(in.Name); err != nil {
 		return nil, shelff.TagOrder{}, err
 	}
-	return s.readTagOrder(context.Background(), nil, struct{}{})
+	return s.readTagOrder(ctx, nil, struct{}{})
 }
 
-func (s *Server) removeTagFromOrder(_ context.Context, _ *mcp.CallToolRequest, in cascadeNameInput) (*mcp.CallToolResult, shelff.TagOrder, error) {
+func (s *Server) removeTagFromOrder(ctx context.Context, _ *mcp.CallToolRequest, in cascadeNameInput) (*mcp.CallToolResult, shelff.TagOrder, error) {
 	if err := s.library.RemoveTagFromOrder(in.Name, in.Cascade); err != nil {
 		return nil, shelff.TagOrder{}, err
 	}
-	return s.readTagOrder(context.Background(), nil, struct{}{})
+	return s.readTagOrder(ctx, nil, struct{}{})
 }
 
-func (s *Server) renameTag(_ context.Context, _ *mcp.CallToolRequest, in renameConfigInput) (*mcp.CallToolResult, shelff.TagOrder, error) {
+func (s *Server) renameTag(ctx context.Context, _ *mcp.CallToolRequest, in renameConfigInput) (*mcp.CallToolResult, shelff.TagOrder, error) {
 	if err := s.library.RenameTag(in.OldName, in.NewName, in.Cascade); err != nil {
 		return nil, shelff.TagOrder{}, err
 	}
-	return s.readTagOrder(context.Background(), nil, struct{}{})
+	return s.readTagOrder(ctx, nil, struct{}{})
 }
 
-func (s *Server) reorderTags(_ context.Context, _ *mcp.CallToolRequest, in reorderNamesInput) (*mcp.CallToolResult, shelff.TagOrder, error) {
+func (s *Server) reorderTags(ctx context.Context, _ *mcp.CallToolRequest, in reorderNamesInput) (*mcp.CallToolResult, shelff.TagOrder, error) {
 	if err := s.library.ReorderTags(in.Names); err != nil {
 		return nil, shelff.TagOrder{}, err
 	}
-	return s.readTagOrder(context.Background(), nil, struct{}{})
+	return s.readTagOrder(ctx, nil, struct{}{})
 }
 
 func openCanonicalLibrary(root string) (*shelff.Library, error) {
@@ -563,6 +563,16 @@ func (s *Server) resolvePath(relative string) (string, error) {
 		return "", err
 	}
 	return resolved, nil
+}
+
+func (s *Server) resolveDirectoryPath(relative string) (string, error) {
+	if strings.TrimSpace(relative) == "" {
+		return "", ErrEmptyPath
+	}
+	if filepath.Clean(filepath.FromSlash(relative)) == "." {
+		return s.library.Root(), nil
+	}
+	return s.resolvePath(relative)
 }
 
 func resolveExistingPath(path string) (string, error) {

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -394,6 +394,7 @@ func TestBookAndConfigMutationTools(t *testing.T) {
 	}
 
 	pdfPath := writeTestPDF(t, incomingDir, "book.pdf")
+	rootMovePDFPath := writeTestPDF(t, incomingDir, "root-move.pdf")
 	sidecar, err := shelff.CreateSidecar(pdfPath)
 	if err != nil {
 		t.Fatalf("CreateSidecar error = %v", err)
@@ -455,6 +456,28 @@ func TestBookAndConfigMutationTools(t *testing.T) {
 	}
 	if _, err := os.Stat(shelff.SidecarPath(renamedPDFPath)); err != nil {
 		t.Fatalf("renamed sidecar missing: %v", err)
+	}
+
+	rootMoveResult, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "move_book",
+		Arguments: map[string]any{
+			"pdfPath": "incoming/root-move.pdf",
+			"destDir": ".",
+		},
+	})
+	if err != nil {
+		t.Fatalf("move_book to root error = %v", err)
+	}
+	bookOut = bookPathOutput{}
+	decodeStructuredContent(t, rootMoveResult, &bookOut)
+	if bookOut.PDFPath != "root-move.pdf" {
+		t.Fatalf("move_book to root output = %#v, want root-move.pdf", bookOut)
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(bookOut.PDFPath))); err != nil {
+		t.Fatalf("root-moved PDF missing: %v", err)
+	}
+	if _, err := os.Stat(rootMovePDFPath); !os.IsNotExist(err) {
+		t.Fatalf("source PDF still exists after root move_book: %v", err)
 	}
 
 	addCategoryResult, err := session.CallTool(context.Background(), &mcp.CallToolParams{
@@ -633,6 +656,7 @@ func TestReadOnlyToolsRejectPathTraversal(t *testing.T) {
 
 	root := t.TempDir()
 	outside := t.TempDir()
+	writeTestPDF(t, root, "inside.pdf")
 	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
 		t.Skipf("os.Symlink unavailable: %v", err)
 	}
@@ -641,25 +665,12 @@ func TestReadOnlyToolsRejectPathTraversal(t *testing.T) {
 	session := newClientSession(t, server)
 	defer session.Close()
 
-	for _, pdfPath := range []string{"../outside.pdf", "escape/outside.pdf"} {
-		result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-			Name:      "read_sidecar",
-			Arguments: map[string]any{"pdfPath": pdfPath},
-		})
-		if err != nil {
-			t.Fatalf("CallTool(%q) error = %v", pdfPath, err)
-		}
-		if !result.IsError {
-			t.Fatalf("CallTool(%q) IsError = false, want true", pdfPath)
-		}
-		if len(result.Content) == 0 {
-			t.Fatalf("CallTool(%q) returned no error content", pdfPath)
-		}
-		text, ok := result.Content[0].(*mcp.TextContent)
-		if !ok || !strings.Contains(text.Text, ErrPathTraversal.Error()) {
-			t.Fatalf("CallTool(%q) content = %#v, want traversal error", pdfPath, result.Content[0])
-		}
-	}
+	assertToolTraversalError(t, session, "read_sidecar", map[string]any{"pdfPath": "../outside.pdf"})
+	assertToolTraversalError(t, session, "read_sidecar", map[string]any{"pdfPath": "escape/outside.pdf"})
+	assertToolTraversalError(t, session, "rename_book", map[string]any{"pdfPath": "../outside.pdf", "newName": "renamed"})
+	assertToolTraversalError(t, session, "rename_book", map[string]any{"pdfPath": "escape/outside.pdf", "newName": "renamed"})
+	assertToolTraversalError(t, session, "move_book", map[string]any{"pdfPath": "inside.pdf", "destDir": "../outside"})
+	assertToolTraversalError(t, session, "move_book", map[string]any{"pdfPath": "inside.pdf", "destDir": "escape"})
 }
 
 func TestNewRejectsMissingRoot(t *testing.T) {
@@ -709,6 +720,28 @@ func decodeStructuredContent(t *testing.T, result *mcp.CallToolResult, out any) 
 	}
 	if err := json.Unmarshal(data, out); err != nil {
 		t.Fatalf("Unmarshal structured content error = %v", err)
+	}
+}
+
+func assertToolTraversalError(t *testing.T, session *mcp.ClientSession, name string, arguments map[string]any) {
+	t.Helper()
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      name,
+		Arguments: arguments,
+	})
+	if err != nil {
+		t.Fatalf("CallTool(%q) error = %v", name, err)
+	}
+	if !result.IsError {
+		t.Fatalf("CallTool(%q) IsError = false, want true", name)
+	}
+	if len(result.Content) == 0 {
+		t.Fatalf("CallTool(%q) returned no error content", name)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok || !strings.Contains(text.Text, ErrPathTraversal.Error()) {
+		t.Fatalf("CallTool(%q) content = %#v, want traversal error", name, result.Content[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add MCP tools for moving/renaming books and mutating category/tag config
- return canonical relative-path or config outputs from the new handlers
- cover the new MCP surface with integration tests for move/rename and cascade updates

## Testing
- go test ./...