### PR TITLE
PR5: document MCP usage and safety notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ On macOS, a shelff library stored in iCloud typically lives at:
 
 You can pass that directory directly as `--root` or `SHELFF_ROOT`.
 
+Because the path contains a space in `Mobile Documents`, quote it in shell commands:
+
+```bash
+shelff-mcp --root "/Users/<user>/Library/Mobile Documents/iCloud~jp~skoji~shelff/Documents/"
+SHELFF_ROOT="/Users/<user>/Library/Mobile Documents/iCloud~jp~skoji~shelff/Documents/" shelff-mcp
+```
+
 For large-scale edits, migrations, or batch mutations, it is safer to work on a copied library first and then sync the results back once you are satisfied.
 
 ### Exposed MCP tools


### PR DESCRIPTION
## Summary
- document the `shelff-mcp` MCP server in the top-level README
- describe root path rules, exposed tools, and `write_sidecar` partial-update semantics
- add the macOS iCloud root example and a safety note about working on a copy for large changes

## Testing
- go test ./...