### PR TITLE
Add CI and release GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go test ./... -count=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        run: |
+          GOOS=darwin GOARCH=arm64 go build -o shelff-mcp-darwin-arm64 ./cmd/shelff-mcp
+          GOOS=darwin GOARCH=amd64 go build -o shelff-mcp-darwin-amd64 ./cmd/shelff-mcp
+          GOOS=linux GOARCH=amd64 go build -o shelff-mcp-linux-amd64 ./cmd/shelff-mcp
+          GOOS=linux GOARCH=arm64 go build -o shelff-mcp-linux-arm64 ./cmd/shelff-mcp
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            shelff-mcp-darwin-arm64
+            shelff-mcp-darwin-amd64
+            shelff-mcp-linux-amd64
+            shelff-mcp-linux-arm64


### PR DESCRIPTION
Closes #20

## Summary
- push to main / PR で テストを実行するCIワークフローを追加
- `vX.Y.Z` タグ push 時に macOS (arm64/amd64) と Linux (arm64/amd64) のバイナリをビルドし、GitHub Release として公開するワークフローを追加

## Workflows
- **ci.yml**: `go test ./... -count=1` を実行（サブモジュール対応済み）
- **release.yml**: 4つのバイナリ（darwin-arm64, darwin-amd64, linux-amd64, linux-arm64）をビルドし、`softprops/action-gh-release` でリリース作成