### PR TITLE
Add Dependabot auto-update and auto-merge (#18)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for minor and patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Dependabot設定を追加（gomod / github-actions、週次更新）
- minor/patchアップデートの自動マージワークフローを追加（majorは手動レビュー）

Closes #18

## GitHub側の設定
自動マージを機能させるために、以下のリポジトリ設定が必要です：

1. **Allow auto-merge を有効化**: Settings → General → Pull Requests → "Allow auto-merge" にチェック
2. **Branch protection rule の設定**: Settings → Branches → main ブランチに対して：
   - "Require a pull request before merging" を有効化
   - "Require status checks to pass before merging" を有効化し、`test` ステータスチェックを必須に設定

## Test plan
- [ ] リポジトリ設定で Allow auto-merge を有効化
- [ ] mainブランチのbranch protection ruleを設定
- [ ] Dependabotが作成するPRで自動マージが動作することを確認