### PR TITLE
Add list_directories and create_directory MCP tools

### DIFF
--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -481,18 +481,27 @@ func (s *Server) scanBooks(_ context.Context, _ *mcp.CallToolRequest, in scanBoo
 func (s *Server) listDirectories(_ context.Context, _ *mcp.CallToolRequest, in listDirectoriesInput) (*mcp.CallToolResult, listDirectoriesOutput, error) {
 	startDir := s.library.Root()
 	if in.Directory != nil {
-		resolved, err := s.resolveDirectoryPath(*in.Directory)
-		if err != nil {
-			return nil, listDirectoriesOutput{}, err
+		dir := strings.TrimSpace(*in.Directory)
+		if dir != "" {
+			resolved, err := s.resolveDirectoryPath(dir)
+			if err != nil {
+				return nil, listDirectoriesOutput{}, err
+			}
+			resolved, err = resolveExistingPath(resolved)
+			if err != nil {
+				return nil, listDirectoriesOutput{}, err
+			}
+			if err := s.ensureWithinRoot(resolved); err != nil {
+				return nil, listDirectoriesOutput{}, err
+			}
+			startDir = resolved
 		}
-		resolved, err = resolveExistingPath(resolved)
-		if err != nil {
-			return nil, listDirectoriesOutput{}, err
-		}
-		if err := s.ensureWithinRoot(resolved); err != nil {
-			return nil, listDirectoriesOutput{}, err
-		}
-		startDir = resolved
+	}
+
+	configDir := filepath.Clean(filepath.Join(s.library.Root(), shelff.ConfigDir))
+	cleanStart := filepath.Clean(startDir)
+	if cleanStart == configDir || strings.HasPrefix(cleanStart, configDir+string(filepath.Separator)) {
+		return nil, listDirectoriesOutput{Directories: []string{}}, nil
 	}
 
 	var dirs []string
@@ -509,7 +518,7 @@ func (s *Server) listDirectories(_ context.Context, _ *mcp.CallToolRequest, in l
 		}
 		rel, err := s.relativePath(filepath.Join(startDir, entry.Name()))
 		if err != nil {
-			continue
+			return nil, listDirectoriesOutput{}, err
 		}
 		dirs = append(dirs, rel)
 		if in.Recursive {
@@ -542,7 +551,7 @@ func (s *Server) listSubdirectories(dir string) ([]string, error) {
 		full := filepath.Join(dir, entry.Name())
 		rel, err := s.relativePath(full)
 		if err != nil {
-			continue
+			return nil, err
 		}
 		dirs = append(dirs, rel)
 		sub, err := s.listSubdirectories(full)

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -951,6 +951,49 @@ func TestListDirectories(t *testing.T) {
 	if want := []string{"a", "a/nested", "b"}; !slices.Equal(out.Directories, want) {
 		t.Fatalf("list_directories recursive = %v, want %v", out.Directories, want)
 	}
+
+	// directory: "" should behave like listing from the root
+	result, err = session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "list_directories",
+		Arguments: map[string]any{"recursive": false, "directory": ""},
+	})
+	if err != nil {
+		t.Fatalf("list_directories with empty directory error = %v", err)
+	}
+	out = listDirectoriesOutput{}
+	decodeStructuredContent(t, result, &out)
+	slices.Sort(out.Directories)
+	if want := []string{"a", "b"}; !slices.Equal(out.Directories, want) {
+		t.Fatalf("list_directories with empty directory = %v, want %v", out.Directories, want)
+	}
+
+	// directory: "a" should return only entries under "a"
+	result, err = session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "list_directories",
+		Arguments: map[string]any{"recursive": true, "directory": "a"},
+	})
+	if err != nil {
+		t.Fatalf("list_directories with directory=a error = %v", err)
+	}
+	out = listDirectoriesOutput{}
+	decodeStructuredContent(t, result, &out)
+	if want := []string{"a/nested"}; !slices.Equal(out.Directories, want) {
+		t.Fatalf("list_directories with directory=a = %v, want %v", out.Directories, want)
+	}
+
+	// directory: ".shelff" should return empty list
+	result, err = session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "list_directories",
+		Arguments: map[string]any{"recursive": true, "directory": ".shelff"},
+	})
+	if err != nil {
+		t.Fatalf("list_directories with directory=.shelff error = %v", err)
+	}
+	out = listDirectoriesOutput{}
+	decodeStructuredContent(t, result, &out)
+	if len(out.Directories) != 0 {
+		t.Fatalf("list_directories with directory=.shelff = %v, want empty", out.Directories)
+	}
 }
 
 func TestCreateDirectory(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `list_directories` MCP tool to list directories in the library (with optional recursive and directory filtering, excluding `.shelff` config dir)
- Add `create_directory` MCP tool to create directories (with parents) within the library
- Both tools reject path traversal attempts

These tools allow AI agents to discover existing directory structure and create new directories before moving books via `move_book`, since agents cannot directly access the filesystem.

## Test plan
- [x] `TestListDirectories` — non-recursive and recursive listing, config dir exclusion, file exclusion
- [x] `TestCreateDirectory` — simple creation, nested creation, idempotent creation
- [x] `TestCreateDirectoryRejectsPathTraversal` — path traversal rejection
- [x] `TestListDirectoriesRejectsPathTraversal` — path traversal rejection
- [x] `TestServerListsReadOnlyTools` — tool registration
- [x] All existing tests pass