### PR TITLE
Fix shelff specification link in library documentation

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -317,5 +317,5 @@ Some commonly returned errors:
 
 ## See also
 
-- [shelff specification](../shelff-schema/SPECIFICATION.md)
+- [shelff specification](https://github.com/skoji/shelff-schema/blob/main/SPECIFICATION.md)
 - [shelff iOS/iPadOS app](https://skoji.dev/en/shelff/)


### PR DESCRIPTION
Updated the link to the shelff specification to point to the GitHub repository.