### PR TITLE
fix: surface collection field in read_metadata output

### DIFF
--- a/shelff/metadata_test.go
+++ b/shelff/metadata_test.go
@@ -265,6 +265,94 @@ func TestWriteMetadataPreservesUnknownTopLevelFields(t *testing.T) {
 	}
 }
 
+func TestReadMetadataReturnsCollection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "book.pdf")
+	if err := os.WriteFile(pdfPath, []byte("%PDF-"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const body = `{
+  "schemaVersion": 1,
+  "metadata": {"dc:title": "Book"},
+  "collection": {"title": "Monthly Swift", "position": 4}
+}`
+	if err := os.WriteFile(shelff.SidecarPath(pdfPath), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, err := shelff.ReadMetadata(pdfPath)
+	if err != nil {
+		t.Fatalf("ReadMetadata error = %v", err)
+	}
+	if meta.Collection == nil {
+		t.Fatal("Collection = nil, want populated")
+	}
+	if meta.Collection.Title != "Monthly Swift" {
+		t.Fatalf("Collection.Title = %q, want %q", meta.Collection.Title, "Monthly Swift")
+	}
+	if meta.Collection.Position == nil || *meta.Collection.Position != 4 {
+		t.Fatalf("Collection.Position = %v, want 4", meta.Collection.Position)
+	}
+}
+
+func TestWriteMetadataAddsCollection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "book.pdf")
+	if err := os.WriteFile(pdfPath, []byte("%PDF-"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, err := shelff.WriteMetadata(pdfPath, map[string]any{
+		"collection": map[string]any{
+			"title":    "Monthly Swift",
+			"position": 7,
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteMetadata error = %v", err)
+	}
+	if meta.Collection == nil {
+		t.Fatal("Collection = nil, want populated")
+	}
+	if meta.Collection.Title != "Monthly Swift" {
+		t.Fatalf("Collection.Title = %q, want %q", meta.Collection.Title, "Monthly Swift")
+	}
+	if meta.Collection.Position == nil || *meta.Collection.Position != 7 {
+		t.Fatalf("Collection.Position = %v, want 7", meta.Collection.Position)
+	}
+}
+
+func TestWriteMetadataDeletesCollection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "book.pdf")
+	if err := os.WriteFile(pdfPath, []byte("%PDF-"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const body = `{
+  "schemaVersion": 1,
+  "metadata": {"dc:title": "Book"},
+  "collection": {"title": "Monthly Swift"}
+}`
+	if err := os.WriteFile(shelff.SidecarPath(pdfPath), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, err := shelff.WriteMetadata(pdfPath, map[string]any{
+		"collection": nil,
+	})
+	if err != nil {
+		t.Fatalf("WriteMetadata error = %v", err)
+	}
+	if meta.Collection != nil {
+		t.Fatalf("Collection = %v, want nil", meta.Collection)
+	}
+}
+
 func TestWriteMetadataReturnsErrPDFNotFound(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/shelff/sidecar.go
+++ b/shelff/sidecar.go
@@ -16,6 +16,7 @@ var (
 		"display":       {},
 		"category":      {},
 		"tags":          {},
+		"collection":    {},
 	}
 )
 
@@ -131,6 +132,9 @@ func validateSidecarMetadata(meta *SidecarMetadata) error {
 		if !meta.Reading.Status.Valid() {
 			return fmt.Errorf("%w: status %q", ErrInvalidFieldValue, *meta.Reading.Status)
 		}
+	}
+	if meta.Collection != nil && meta.Collection.Title == "" {
+		return fmt.Errorf("%w: collection.title must not be empty", ErrInvalidFieldValue)
 	}
 	return nil
 }

--- a/shelff/sidecar_test.go
+++ b/shelff/sidecar_test.go
@@ -575,6 +575,156 @@ func TestReadSidecarAcceptsInvalidEnumValues(t *testing.T) {
 	}
 }
 
+func TestReadSidecarParsesCollection(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pdfPath := writeTestPDF(t, root, "book.pdf")
+	sidecarPath := shelff.SidecarPath(pdfPath)
+	const body = `{
+  "schemaVersion": 1,
+  "metadata": {
+    "dc:title": "Book"
+  },
+  "collection": {
+    "title": "Monthly Swift",
+    "position": 3.5
+  }
+}`
+	writeFile(t, sidecarPath, []byte(body))
+
+	meta, err := shelff.ReadSidecar(pdfPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar returned error: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("ReadSidecar returned nil")
+	}
+	if meta.Collection == nil {
+		t.Fatal("Collection = nil, want populated")
+	}
+	if meta.Collection.Title != "Monthly Swift" {
+		t.Fatalf("Collection.Title = %q, want %q", meta.Collection.Title, "Monthly Swift")
+	}
+	if meta.Collection.Position == nil {
+		t.Fatal("Collection.Position = nil, want 3.5")
+	}
+	if *meta.Collection.Position != 3.5 {
+		t.Fatalf("Collection.Position = %v, want 3.5", *meta.Collection.Position)
+	}
+}
+
+func TestReadSidecarParsesCollectionWithoutPosition(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pdfPath := writeTestPDF(t, root, "book.pdf")
+	sidecarPath := shelff.SidecarPath(pdfPath)
+	const body = `{
+  "schemaVersion": 1,
+  "metadata": {
+    "dc:title": "Book"
+  },
+  "collection": {
+    "title": "Quarterly Review"
+  }
+}`
+	writeFile(t, sidecarPath, []byte(body))
+
+	meta, err := shelff.ReadSidecar(pdfPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar returned error: %v", err)
+	}
+	if meta.Collection == nil {
+		t.Fatal("Collection = nil, want populated")
+	}
+	if meta.Collection.Title != "Quarterly Review" {
+		t.Fatalf("Collection.Title = %q, want %q", meta.Collection.Title, "Quarterly Review")
+	}
+	if meta.Collection.Position != nil {
+		t.Fatalf("Collection.Position = %v, want nil", *meta.Collection.Position)
+	}
+}
+
+func TestWriteSidecarRoundTripsCollection(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pdfPath := writeTestPDF(t, root, "book.pdf")
+	position := 2.0
+	meta := &shelff.SidecarMetadata{
+		SchemaVersion: shelff.SchemaVersion,
+		Metadata: shelff.DublinCore{
+			Title: "Book",
+		},
+		Collection: &shelff.Collection{
+			Title:    "Intro to Swift",
+			Position: &position,
+		},
+	}
+
+	if err := shelff.WriteSidecar(pdfPath, meta); err != nil {
+		t.Fatalf("WriteSidecar returned error: %v", err)
+	}
+
+	decoded := decodeJSONFile(t, shelff.SidecarPath(pdfPath))
+	collection, ok := decoded["collection"].(map[string]any)
+	if !ok {
+		t.Fatalf("collection = %#v, want JSON object", decoded["collection"])
+	}
+	if collection["title"] != "Intro to Swift" {
+		t.Fatalf("collection.title = %#v, want %q", collection["title"], "Intro to Swift")
+	}
+	if got := collection["position"].(json.Number).String(); got != "2" {
+		t.Fatalf("collection.position = %#v, want 2", collection["position"])
+	}
+
+	readBack, err := shelff.ReadSidecar(pdfPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar returned error: %v", err)
+	}
+	if readBack.Collection == nil || readBack.Collection.Title != "Intro to Swift" {
+		t.Fatalf("readBack.Collection = %#v, want title %q", readBack.Collection, "Intro to Swift")
+	}
+	if readBack.Collection.Position == nil || *readBack.Collection.Position != 2.0 {
+		t.Fatalf("readBack.Collection.Position = %#v, want 2", readBack.Collection.Position)
+	}
+}
+
+func TestWriteSidecarOmitsCollectionWhenNil(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pdfPath := writeTestPDF(t, root, "book.pdf")
+	meta := &shelff.SidecarMetadata{
+		SchemaVersion: shelff.SchemaVersion,
+		Metadata:      shelff.DublinCore{Title: "Book"},
+	}
+	if err := shelff.WriteSidecar(pdfPath, meta); err != nil {
+		t.Fatalf("WriteSidecar returned error: %v", err)
+	}
+	data := string(readFile(t, shelff.SidecarPath(pdfPath)))
+	if strings.Contains(data, `"collection"`) {
+		t.Fatalf("expected no collection key, got %s", data)
+	}
+}
+
+func TestWriteSidecarRejectsCollectionWithoutTitle(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pdfPath := writeTestPDF(t, root, "book.pdf")
+	meta := &shelff.SidecarMetadata{
+		SchemaVersion: shelff.SchemaVersion,
+		Metadata:      shelff.DublinCore{Title: "Book"},
+		Collection:    &shelff.Collection{},
+	}
+	err := shelff.WriteSidecar(pdfPath, meta)
+	if !errors.Is(err, shelff.ErrInvalidFieldValue) {
+		t.Fatalf("WriteSidecar with empty collection title: got %v, want ErrInvalidFieldValue", err)
+	}
+}
+
 func writeTestPDF(t *testing.T, dir string, name string) string {
 	t.Helper()
 

--- a/shelff/types.go
+++ b/shelff/types.go
@@ -10,8 +10,17 @@ type SidecarMetadata struct {
 	Display       *DisplaySettings `json:"display,omitempty"`
 	Category      *string          `json:"category,omitempty"`
 	Tags          []string         `json:"tags,omitempty"`
+	Collection    *Collection      `json:"collection,omitempty"`
 
 	rawJSON []byte
+}
+
+// Collection represents a series or magazine a book belongs to.
+// Based on EPUB's belongs-to-collection / group-position concepts,
+// simplified to a single collection without a type distinction.
+type Collection struct {
+	Title    string   `json:"title"`
+	Position *float64 `json:"position,omitempty"`
 }
 
 // DublinCore holds Dublin Core metadata fields.


### PR DESCRIPTION
## Summary
- スキーマには `collection` (series/magazine) が定義されているが、Go の `SidecarMetadata` 構造体に対応フィールドが無く、`ReadSidecar` / `ReadMetadata` の `json.Unmarshal` で破棄されていた。`WriteMetadata` は raw JSON マップマージ + 未知トップレベルキー保存ルートで偶然書けていたため、書きはできているのに読みで消える、という非対称が生じていた。
- `Collection` 型と `SidecarMetadata.Collection` フィールドを追加。`knownSidecarTopLevelKeys` に `"collection"` を登録して typed パスで一貫して読み書きするようにし、`validateSidecarMetadata` に `collection.title` 必須チェックを追加。
- TDD 順（テスト先行で失敗確認 → 実装）でコミットを分割。

## Test plan
- [x] `go test ./...` 全パス
- [x] `go vet ./...` / `go build ./...` クリーン
- [x] 新規テスト: `TestReadSidecarParsesCollection`, `TestReadSidecarParsesCollectionWithoutPosition`, `TestWriteSidecarRoundTripsCollection`, `TestWriteSidecarOmitsCollectionWhenNil`, `TestWriteSidecarRejectsCollectionWithoutTitle`, `TestReadMetadataReturnsCollection`, `TestWriteMetadataAddsCollection`, `TestWriteMetadataDeletesCollection`
- [x] レビュー: local-diff-review はスキップ、codex-diff-review で MUST/CONSIDER ゼロ

https://claude.ai/code/session_013foftuTkpm64m1CKBwUTma